### PR TITLE
Fix python jar linking

### DIFF
--- a/jgo/jgo.py
+++ b/jgo/jgo.py
@@ -344,6 +344,7 @@ def resolve_dependencies(
         endpoint_string,
         cache_dir,
         m2_repo,
+        link_type='hard',
         update_cache=False,
         force_update=False,
         manage_dependencies=False,
@@ -457,7 +458,7 @@ def resolve_dependencies(
             relevant_jars.append(jar_file_in_workspace)
 
             try:
-                link(os.path.join(m2_repo, *g.split('.'), a, version, jar_file), jar_file_in_workspace)
+                link(os.path.join(m2_repo, *g.split('.'), a, version, jar_file), jar_file_in_workspace, link_type=link_type)
             except FileExistsError as e:
                 # Do not throw exceptionif target file exists.
                 pass
@@ -493,6 +494,7 @@ def run(parser, argv=sys.argv[1:]):
 
     cache_dir = settings.get('cacheDir')
     m2_repo   = settings.get('m2Repo')
+    link_type = settings.get('links')
     for repository in args.repository:
         repositories[repository.split('=')[0]] = repository.split('=')[1]
 
@@ -514,7 +516,8 @@ def run(parser, argv=sys.argv[1:]):
         manage_dependencies = args.manage_dependencies,
         repositories        = repositories,
         shortcuts           = shortcuts,
-        verbose             = args.verbose)
+        verbose             = args.verbose,
+        link_type           = link_type)
 
     main_class_file = os.path.join(workspace, primary_endpoint.main_class, 'mainClass') if primary_endpoint.main_class else os.path.join(workspace, 'mainClass')
 

--- a/jgo/jgo.py
+++ b/jgo/jgo.py
@@ -213,7 +213,7 @@ and it will be auto-completed.
 
     parser = argparse.ArgumentParser(
         description     = 'Run Java main class from maven coordinates.',
-        usage           = '%(prog)s [-v] [-u] [-U] [-m] [--ignore-jgorc] [--additional-jars jar [jar ...]] [--additional-endpoints endpoint [endpoint ...]] [JVM_OPTIONS [JVM_OPTIONS ...]] <endpoint> [main-args]',
+        usage           = '%(prog)s [-v] [-u] [-U] [-m] [--ignore-jgorc] [--link-type type] [--additional-jars jar [jar ...]] [--additional-endpoints endpoint [endpoint ...]] [JVM_OPTIONS [JVM_OPTIONS ...]] <endpoint> [main-args]',
         epilog          = epilog,
         formatter_class = argparse.RawTextHelpFormatter
     )
@@ -225,6 +225,7 @@ and it will be auto-completed.
     parser.add_argument('-a', '--additional-jars', nargs='+', help='Add additional jars to classpath', default=[], required=False)
     parser.add_argument( '--additional-endpoints', nargs='+', help='Add additional endpoints', default=[], required=False)
     parser.add_argument('--ignore-jgorc', action='store_true', help='Ignore ~/.jgorc')
+    parser.add_argument('--link-type', default=None, type=str, help='How to link from local maven repository into jgo cache. Defaults to the `links\' setting in ~/.jrunrc or \'hard\' if not specified.', choices=('hard', 'soft', 'copy'))
 
 
     try:
@@ -491,6 +492,9 @@ def run(parser, argv=sys.argv[1:]):
 
     if args.verbose > 0:
         _logger.setLevel(logging.DEBUG)
+
+    if args.link_type is not None:
+        config.set('settings', 'links', args.link_type)
 
     cache_dir = settings.get('cacheDir')
     m2_repo   = settings.get('m2Repo')


### PR DESCRIPTION
This addresses multiple issues with Python jar linking:
 - link type was ignored (#24)
 - link type was not a command line argument (#25)
 - no auto mode for link type (#22)

Fixes only partially #22 
Fixes #24 
Fixes #25 

@ctrueden do you have any objections against resolving #22 with a Python-only solution?