### PR TITLE
Return exit code of launched Java application

### DIFF
--- a/jgo.sh
+++ b/jgo.sh
@@ -307,7 +307,7 @@ then
 	check cat
 	mainClass=$(cat "$workspace/mainClass")
 	launchJava
-	exit 0
+	exit $?
 fi
 
 # Synthesize a dummy Maven project.


### PR DESCRIPTION
When using `jgo` from shell scripts I have found it desirable to detect the exit code of the launched Java application. This small change achieves that.