### PR TITLE
Do not update local jgo test unless -u or -U option specified

### DIFF
--- a/jgo/jgo.py
+++ b/jgo/jgo.py
@@ -391,10 +391,12 @@ def resolve_dependencies(
     workspace           = workspace_dir_from_coordinates(coordinates, cache_dir=cache_dir)
 
     update_cache = True if force_update else update_cache
-    update_cache = update_cache or os.path.isdir(workspace)
+    update_cache = update_cache \
+                   or not os.path.isdir(workspace) \
+                   or os.path.isdir(workspace) and not os.path.isfile(os.path.join(workspace, 'mainClass'))
 
     if not update_cache:
-        primary_endpoint, workspace
+        return primary_endpoint, workspace
 
     if update_cache:
         shutil.rmtree(workspace, True)


### PR DESCRIPTION
Fixes #27

For comparison, run this script:
```sh
#/usr/bin/env sh

if [ -z "${CONDA_PREFIX}" ]; then
    export PATH=$HOME/.local/bin:$PATH
fi

echo "Time with update"
time jgo -u org.janelia.saalfeldlab:paintera:0.8.2 --version 2>/dev/null
echo
echo
echo "Time without update"
time jgo org.janelia.saalfeldlab:paintera:0.8.2 --version 2>/dev/null
```

On latest conda-forge release:
```
Time with update

real    0m1.956s
user    0m5.883s
sys     0m0.240s


Time without update

real    0m1.912s
user    0m5.728s
sys     0m0.275s
```

On this PR branch:
```
Time with update

real    0m1.846s
user    0m5.401s
sys     0m0.270s


Time without update

real    0m0.369s
user    0m0.550s
sys     0m0.070s
```