### PR TITLE
Removing hard-coded logging configuration

### DIFF
--- a/jgo/jgo.py
+++ b/jgo/jgo.py
@@ -26,11 +26,6 @@ import zipfile
 
 _classpath_separator = ';' if os.name == 'nt' else ':'
 
-LOG_FORMAT = '%(levelname)s %(asctime)s: %(message)s'
-logging.basicConfig(
-    level   = logging.INFO,
-    # datefmt = '%Y-%m-%d -  %H:%M:%S',
-    format  = LOG_FORMAT)
 _logger = logging.getLogger(os.getenv('JRUN_LOGGER_NAME', 'jgo'))
 
 def classpath_separator():

--- a/jgo/jgo.py
+++ b/jgo/jgo.py
@@ -245,6 +245,12 @@ and it will be auto-completed.
     return parser
 
 def jgo_main(argv=sys.argv[1:], stdout=None, stderr=None):
+	
+    LOG_FORMAT = '%(levelname)s %(asctime)s: %(message)s'
+    logging.basicConfig(
+        level   = logging.INFO,
+        # datefmt = '%Y-%m-%d -  %H:%M:%S',
+        format  = LOG_FORMAT)
 
     parser = jgo_parser()
 


### PR DESCRIPTION
Using logging.basicConfig at this level of the program leads to this logging configuration being forced upon all programs that import jgo. Seeing how useful jgo is as a library, it should follow the python logging convention of libraries not hard-coding the logging configuration: https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library

----

Example code:
```
import logging
logging.basicConfig(filename='example.log', level=logging.DEBUG)
logger = logging.getLogger(__name__)
print(logger.name)
logger.debug('This message should go to the log file')
logger.info('So should this')
logger.warning('And this, too')
```
This code logs a few example messages to a log file. No library import should change how this code works. Adding `import jgo` at the beginning (or importing any library with `jgo` as a dependency, [see issue here](https://github.com/imagej/pyimagej/issues/40)) changes the behavior of the logger, such that the logging level is set to INFO and logging is sent to the console, not the file. The reason for this is the hard-coded logging.basicConfig in the jgo library. Removing lines 29-33 from jgo.jgo.py fixes this issue.

-----

I tested that this does not interfere with using the jgo library via pyimagej. If anything relies on jgo logging (hopefully not), that would need to be adapted. If other libraries did not initialize the logging and relied on the jgo initialization, logging.INFO messages wouldn't be automatically displayed anymore. Warnings would still be printed to the console if no logging is set up.