### PR TITLE
Move try except into run_and_combine_outputs function

### DIFF
--- a/jgo/jgo.py
+++ b/jgo/jgo.py
@@ -197,22 +197,38 @@ def launch_java(
     return subprocess.run((java, '-cp', cp) + jvm_args + (main_class,) + app_args, stdout=stdout, stderr=stderr, **subprocess_run_kwargs)
 
 def run_and_combine_outputs(command, *args):
-    try:
-        return subprocess.check_output((command,) + args, stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError as e:
-        _logger.error("Error in `%s': %d", ' '.join(e.cmd), e.returncode)
-        _logger.debug("Exception: %s", e)
-        _logger.debug("Debug Trace:", exc_info=True)
-        if e.stdout:
-            _logger.debug("\tstd out:")
-            for l in str(e.stdout).split('\\n'):
-                _logger.debug('\t\t%s', l)
-        if e.stderr:
-            _logger.debug("\tstd err:")
-            for l in str(e.stderr).split('\\n'):
-                _logger.debug('\t\t%s', l)
-        # parser.print_help(file=sys.stderr)
-        sys.exit(e.returncode)
+	try:
+		return subprocess.check_output((command,) + args, stderr=subprocess.STDOUT)
+	except subprocess.CalledProcessError as e:
+		_logger.error("Error in `%s': %d", ' '.join(e.cmd), e.returncode)
+		_logger.debug("Exception: %s", e)
+		_logger.debug("Debug Trace:", exc_info=True)
+		if e.stdout:
+			_logger.debug("\tstd out:")
+			for l in str(e.stdout).split('\\n'):
+				_logger.debug('\t\t%s', l)
+		if e.stderr:
+			_logger.debug("\tstd err:")
+			for l in str(e.stderr).split('\\n'):
+				_logger.debug('\t\t%s', l)
+		# parser.print_help(file=sys.stderr)
+		sys.exit(e.returncode)
+		
+	except NoMainClassInManifest as e:
+		_logger.error(e)
+		_logger.error("No main class given, and none found.")
+		# parser.print_help(file=sys.stderr)
+		sys.exit(1)
+
+	except HelpRequested as e:
+		pass
+		#parser.parse_known_args(e.argv)
+
+	except Exception as e:
+		_logger.error(e)
+		traceback.print_tb(e.__traceback__)
+		parser.print_help(file=sys.stderr)
+		sys.exit(1)
 
 def find_endpoint(argv, shortcuts={}):
     # endpoint is first positional argument
@@ -270,21 +286,6 @@ def jgo_main(argv=sys.argv[1:], stdout=None, stderr=None):
 
     completed_process = run(parser, argv=argv, stdout=stdout, stderr=stderr)
     completed_process.check_returncode()
-
-    except NoMainClassInManifest as e:
-        _logger.error(e)
-        _logger.error("No main class given, and none found.")
-        parser.print_help(file=sys.stderr)
-        sys.exit(1)
-
-    except HelpRequested as e:
-        parser.parse_known_args(e.argv)
-
-    except Exception as e:
-        _logger.error(e)
-        traceback.print_tb(e.__traceback__)
-        parser.print_help(file=sys.stderr)
-        sys.exit(1)
 
 
 def jgo_cache_dir_environment_variable():


### PR DESCRIPTION
The try except for the `subprocess.check_output` seems to be required to be in the function that calls `subprocess.check_output`. If it's in a function that calls a function that calls `subprocess.check_output` (as it is so far), it does not catch the output and therefore does not work.

This pull request would take it into the `run_and_combine_outputs` function. In my tests, this then provides the actual error messages to the console (see [this forum thread ](https://forum.image.sc/t/using-pyinstaller-on-a-program-that-uses-pyimagej/26642/5)for details).

The only thing I haven't been able to here is integrate it with the parser for the `parser.print_help(file=sys.stderr)`. Could that be done from within `run_and_combine_outputs`? Can the parser be initialized multiple times or passed to the `run_and_combine_outputs ` function?