### PR TITLE
Log first-time start up and warn about potentially slow start-up time

### DIFF
--- a/jgo.sh
+++ b/jgo.sh
@@ -13,6 +13,7 @@
 
 # Define some useful functions.
 
+notice() { test $quiet || echo "$@"; }
 info() { test $verbose && echo "[INFO] $@"; }
 err() { echo "$@" 1>&2; }
 die() { err "$@"; exit 1; }
@@ -180,6 +181,9 @@ do
 				updateMaven=1
 				updateCache=1
 				;;
+                        -q)
+				quiet=1
+				;;
 			-*)
 				jvm_args+=("$1")
 				;;
@@ -244,12 +248,13 @@ do
 			v="RELEASE"
 			;;
 		*)
-			echo "Usage: jgo [-v] [-u] [-U] [-m] <jvm-args> <endpoint> <main-args>"
+			echo "Usage: jgo [-v] [-u] [-U] [-m] [-q] <jvm-args> <endpoint> <main-args>"
 			echo
 			echo "  -v          : verbose mode flag"
 			echo "  -u          : update/regenerate cached environment"
 			echo "  -U          : force update from remote Maven repositories (implies -u)"
 			echo "  -m          : use endpoints for dependency management (see README)"
+			echo "  -q          : quiet mode flag to suppress regular output"
 			echo "  <jvm-args>  : any list of arguments to the JVM"
 			echo "  <endpoint>  : the artifact(s) + main class to execute"
 			echo "  <main-args> : any list of arguments to the main class"
@@ -310,7 +315,7 @@ then
 	exit $?
 fi
 
-info 'First time start-up may be slow. Downloaded dependencies will be cached for shorter start-up times in subsequent executions.'
+notice 'First time start-up may be slow. Downloaded dependencies will be cached for shorter start-up times in subsequent executions.'
 
 # Synthesize a dummy Maven project.
 

--- a/jgo.sh
+++ b/jgo.sh
@@ -310,6 +310,8 @@ then
 	exit $?
 fi
 
+info 'First time start-up may be slow. Downloaded dependencies will be cached for shorter start-up times in subsequent executions.'
+
 # Synthesize a dummy Maven project.
 
 for repository in "${repositories[@]}"

--- a/jgo/jgo.py
+++ b/jgo/jgo.py
@@ -239,7 +239,9 @@ def find_endpoint(argv, shortcuts={}):
             indices.append(index)
     return -1 if len(indices) == 0 else indices[-1]
 
-def jgo_parser():
+_default_log_levels = ('NOTSET', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL', 'FATAL', 'TRACE')
+
+def jgo_parser(log_levels = _default_log_levels):
 
     epilog='''
 The endpoint should have one of the following formats:
@@ -258,7 +260,7 @@ and it will be auto-completed.
 
     parser = argparse.ArgumentParser(
         description     = 'Run Java main class from maven coordinates.',
-        usage           = '%(prog)s [-v] [-u] [-U] [-m] [--ignore-jgorc] [--link-type type] [--additional-jars jar [jar ...]] [--additional-endpoints endpoint [endpoint ...]] [JVM_OPTIONS [JVM_OPTIONS ...]] <endpoint> [main-args]',
+        usage           = '%(prog)s [-v] [-u] [-U] [-m] [-q] [--log-level] [--ignore-jgorc] [--link-type type] [--additional-jars jar [jar ...]] [--additional-endpoints endpoint [endpoint ...]] [JVM_OPTIONS [JVM_OPTIONS ...]] <endpoint> [main-args]',
         epilog          = epilog,
         formatter_class = argparse.RawTextHelpFormatter
     )
@@ -268,19 +270,23 @@ and it will be auto-completed.
     parser.add_argument('-m', '--manage-dependencies', action='store_true', help='use endpoints for dependency management (see "Details" below)')
     parser.add_argument('-r', '--repository', nargs='+', help='Add additional maven repository (key=url format)', default=[], required=False)
     parser.add_argument('-a', '--additional-jars', nargs='+', help='Add additional jars to classpath', default=[], required=False)
+    parser.add_argument('-q', '--quiet', action='store_true', required=False, help='Suppress jgo output, including logging')
     parser.add_argument( '--additional-endpoints', nargs='+', help='Add additional endpoints', default=[], required=False)
     parser.add_argument('--ignore-jgorc', action='store_true', help='Ignore ~/.jgorc')
     parser.add_argument('--link-type', default=None, type=str, help='How to link from local maven repository into jgo cache. Defaults to the `links\' setting in ~/.jgorc or \'auto\' if not specified.', choices=('hard', 'soft', 'copy', 'auto'))
+    parser.add_argument('--log-level', default=None, type=str, help='Set log level')
 
     return parser
 
 def jgo_main(argv=sys.argv[1:], stdout=None, stderr=None):
 
     LOG_FORMAT = '%(levelname)s %(asctime)s: %(message)s'
-    logging.basicConfig(
-        level   = logging.INFO,
-        # datefmt = '%Y-%m-%d -  %H:%M:%S',
-        format  = LOG_FORMAT)
+
+    if not ('-q' in argv or '--quiet' in argv):
+        logging.basicConfig(
+            level   = logging.INFO,
+            # datefmt = '%Y-%m-%d -  %H:%M:%S',
+            format  = LOG_FORMAT)
 
     parser = jgo_parser()
 
@@ -379,8 +385,7 @@ def resolve_dependencies(
         manage_dependencies=False,
         repositories={},
         shortcuts={},
-        verbose=0
-):
+        verbose=0):
 
 
     endpoint_strings    = split_endpoint_string(endpoint_string)
@@ -398,6 +403,10 @@ def resolve_dependencies(
 
     if not update_cache:
         return primary_endpoint, workspace
+
+    _logger.info('First time start-up may be slow. '
+                 'Downloaded dependencies will be cached '
+                 'for shorter start-up times in subsequent executions.')
 
     if update_cache:
         shutil.rmtree(workspace, True)
@@ -519,6 +528,7 @@ def run(parser, argv=sys.argv[1:], stdout=None, stderr=None):
     args, unknown = parser.parse_known_args(argv[:endpoint_index])
     jvm_args      = unknown if unknown else []
     program_args  = [] if endpoint_index == -1 else argv[endpoint_index+1:]
+    if args.log_level: logging.getLogger().setLevel(logging.getLevelName(args.log_level))
 
     if args.verbose > 0:
         _logger.setLevel(logging.DEBUG)
@@ -554,7 +564,6 @@ def run(parser, argv=sys.argv[1:], stdout=None, stderr=None):
         link_type           = link_type)
 
     main_class_file = os.path.join(workspace, primary_endpoint.main_class, 'mainClass') if primary_endpoint.main_class else os.path.join(workspace, 'mainClass')
-
     try:
         with open(main_class_file, 'r') as f:
             main_class = f.readline()
@@ -562,9 +571,6 @@ def run(parser, argv=sys.argv[1:], stdout=None, stderr=None):
     except FileNotFoundError:
         pass
 
-    _logger.info('First time start-up may be slow. '
-                 'Downloaded dependencies will be cached '
-                 'for shorter start-up times in subsequent executions.')
     if not primary_endpoint.main_class:
         jar_path = glob.glob(os.path.join(workspace, primary_endpoint.jar_name()).replace(Endpoint.VERSION_RELEASE, '*').replace(Endpoint.VERSION_LATEST, '*'))[0]
         with zipfile.ZipFile(jar_path) as jar_file:

--- a/jgo/jgo.py
+++ b/jgo/jgo.py
@@ -274,7 +274,7 @@ and it will be auto-completed.
     parser.add_argument( '--additional-endpoints', nargs='+', help='Add additional endpoints', default=[], required=False)
     parser.add_argument('--ignore-jgorc', action='store_true', help='Ignore ~/.jgorc')
     parser.add_argument('--link-type', default=None, type=str, help='How to link from local maven repository into jgo cache. Defaults to the `links\' setting in ~/.jgorc or \'auto\' if not specified.', choices=('hard', 'soft', 'copy', 'auto'))
-    parser.add_argument('--log-level', default=None, type=str, help='Set log level')
+    parser.add_argument('--log-level', default=None, type=str, help='Set log level', choices=log_levels)
 
     return parser
 

--- a/jgo/jgo.py
+++ b/jgo/jgo.py
@@ -562,6 +562,9 @@ def run(parser, argv=sys.argv[1:], stdout=None, stderr=None):
     except FileNotFoundError:
         pass
 
+    _logger.info('First time start-up may be slow. '
+                 'Downloaded dependencies will be cached '
+                 'for shorter start-up times in subsequent executions.')
     if not primary_endpoint.main_class:
         jar_path = glob.glob(os.path.join(workspace, primary_endpoint.jar_name()).replace(Endpoint.VERSION_RELEASE, '*').replace(Endpoint.VERSION_LATEST, '*'))[0]
         with zipfile.ZipFile(jar_path) as jar_file:


### PR DESCRIPTION
Things to consider:
 1. The actual message
 2. currently, this message only shows with the `-v` flag in `jgo.sh`. Should we add another log level `warn` that does not check for `verbose`?

cc @ctrueden 

fixes #40 