### PR TITLE
Remove erroneous parser.print_help line

### DIFF
--- a/jgo/jgo.py
+++ b/jgo/jgo.py
@@ -211,23 +211,19 @@ def run_and_combine_outputs(command, *args):
             _logger.debug("\tstd err:")
             for l in str(e.stderr).split('\\n'):
                 _logger.debug('\t\t%s', l)
-        # parser.print_help(file=sys.stderr)
         sys.exit(e.returncode)
 
     except NoMainClassInManifest as e:
         _logger.error(e)
         _logger.error("No main class given, and none found.")
-        # parser.print_help(file=sys.stderr)
         sys.exit(1)
 
-    except HelpRequested as e:
+    except HelpRequested:
         pass
-    #parser.parse_known_args(e.argv)
 
     except Exception as e:
         _logger.error(e)
         traceback.print_tb(e.__traceback__)
-        parser.print_help(file=sys.stderr)
         sys.exit(1)
 
 def find_endpoint(argv, shortcuts={}):


### PR DESCRIPTION
Also, remove commented out parser.<func> lines and unused variable `e`.

Use of `parser` was commented out in this function. One such line had remained uncommented and would throw an exception.