### PR TITLE
Remove redundant python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     packages=["jgo"],
     test_suite="nose.collector",
     entry_points={"console_scripts": ["jgo=jgo:main"]},
-    python_requires=">=3",
     install_requires=["psutil"],
     tests_require=["nose>=1.0"],
 )

--- a/tests/test_managed.py
+++ b/tests/test_managed.py
@@ -1,6 +1,7 @@
 import glob
 from jgo.jgo import InvalidEndpoint
 import jgo
+import re
 import os
 import pathlib
 import unittest
@@ -32,6 +33,13 @@ def resolve_managed(endpoint, cache_dir, m2_repo):
         repositories=REPOSITORIES,
     )
 
+def find_jar_matching(jars, pattern):
+    for jar in jars:
+        lastindex = jar.rindex('/')
+        if jar[lastindex:].find(pattern) != -1:
+            return jar
+    return None
+
 
 class ManagedDependencyTest(unittest.TestCase):
     def test_resolve_managed(self):
@@ -42,14 +50,16 @@ class ManagedDependencyTest(unittest.TestCase):
                 MANAGED_ENDPOINT, cache_dir=tmp_dir, m2_repo=m2_repo
             )
             jars = glob.glob(os.path.join(workspace, "*jar"))
-            self.assertEqual(len(jars), 4, "Expected two jars in workspace")
+            self.assertEqual(len(jars), 4, "Expected four jars in workspace")
+            sj_common_jar = find_jar_matching(jars, 'scijava-common')
             self.assertEqual(
-                jars[2],
+                sj_common_jar,
                 os.path.join(workspace, "scijava-common-%s.jar" % SJC_VERSION),
                 "Expected scijava-common jar",
             )
+            sj_optional_jar = find_jar_matching(jars, 'scijava-optional')
             self.assertEqual(
-                jars[3],
+                sj_optional_jar,
                 os.path.join(
                     workspace, "scijava-optional-%s.jar" % SJC_OPTIONAL_VERSION
                 ),


### PR DESCRIPTION
There were two python version requirements in `setup.py`, which leads to the following error.

```
~/miniconda3/envs/napari-imagej/bin/pip install -e .                                                                                                                                                                                                   # I 0 {2022-04-04 9:18:57}
Obtaining file:///home/gselzer/code/scijava/jgo
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [7 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/home/gselzer/code/scijava/jgo/setup.py", line 23
          python_requires=">=3",
          ^
      SyntaxError: keyword argument repeated
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

 This PR removes the less strict of the two requirements.