### PR TITLE
fix: don't include paths starting with Windows drive letters as endpoints

### DIFF
--- a/jgo/jgo.py
+++ b/jgo/jgo.py
@@ -265,7 +265,7 @@ def run_and_combine_outputs(command, *args):
 
 def find_endpoint(argv, shortcuts={}):
     # endpoint is first positional argument
-    pattern = re.compile(".*https?://.*")
+    pattern = re.compile("(.*https?://.*|\S:\\.*)")
     indices = []
     for index, arg in enumerate(argv):
         if arg in shortcuts or (Endpoint.is_endpoint(arg) and not pattern.match(arg)):

--- a/jgo/jgo.py
+++ b/jgo/jgo.py
@@ -265,7 +265,7 @@ def run_and_combine_outputs(command, *args):
 
 def find_endpoint(argv, shortcuts={}):
     # endpoint is first positional argument
-    pattern = re.compile("(.*https?://.*|\S:\\.*)")
+    pattern = re.compile("(.*https?://.*|[a-zA-Z]:\\.*)")
     indices = []
     for index, arg in enumerate(argv):
         if arg in shortcuts or (Endpoint.is_endpoint(arg) and not pattern.match(arg)):


### PR DESCRIPTION
When an argument passed to jgo starts with a windows drive letter (e.g. Z:\\), it detects this as a valid endpoint, and the endpoint index is much farther than it otherwise should be. This results in the last positional arg jgo attempts to parse to receive all the extra arguments, that should have otherwise been passed to the program jgo is launching. In my case, it was passing these extra args to the `-r` or `repository` flag, and failing since the windows paths were not valid maven repositories. 

There already was present a check to ignore args that match `Endpoint.is_endpoint` but contain `https://`, so I added an additional check to ignore an arg starting with a windows drive letter when considering the endpoint index.