### PR TITLE
propagate return code in `util.main_from_endpoint`

### DIFF
--- a/src/jgo/util.py
+++ b/src/jgo/util.py
@@ -98,4 +98,4 @@ def main_from_endpoint(
         + paintera_argv
     )
 
-    main(argv=argv)
+    return main(argv=argv)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -487,5 +487,13 @@ class TestUtil(unittest.TestCase):
         self.assertIn("org.slf4j:slf4j-simple", coordinates)
 
 
+class TestUtilMainCaughtExceptions(unittest.TestCase):
+    def test_without_endpoint(self):
+        rv = main_from_endpoint(
+            "", argv=[], primary_endpoint_version="", secondary_endpoints=()
+        )
+        self.assertEqual(rv, 254, "Expected return code 254.")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When building tools based on jgo, `util.main_from_endpoint` is super useful to build up command line tools. Currently, however, it doesn't return the return code - so it is not possible for consumers to tell programmatically whether the jgo run was successful.

This PR makes sure to return the returncode.